### PR TITLE
Added appId to requests

### DIFF
--- a/src/wikitree_api.ts
+++ b/src/wikitree_api.ts
@@ -42,6 +42,8 @@ export interface ApiOptions {
   auth?: WikiTreeAuthentication;
   /** Alternative API URL. */
   apiUrl?: string;
+  /** Optional appId. */
+  appId?: string;
 }
 
 /** Sends a request to the WikiTree API. Returns the raw response. */
@@ -49,6 +51,7 @@ export async function fetchWikiTree(
   request: WikiTreeRequest,
   options?: ApiOptions
 ) {
+  request.appId ??= options?.appId;
   const requestData = new FormData();
   requestData.append('format', 'json');
   for (const key in request) {
@@ -74,6 +77,7 @@ export async function wikiTreeGet(
   request: WikiTreeRequest,
   options?: ApiOptions
 ) {
+  request.appId ??= options?.appId;
   const response = await fetchWikiTree(request, options);
   const result = await response.json();
   if (result[0]?.status) {
@@ -84,6 +88,7 @@ export async function wikiTreeGet(
 
 /** Optional arguments for the GetPerson API call. */
 export interface GetPersonArgs {
+  appId?: string;
   bioFormat?: BioFormat;
   fields?: Array<PersonField> | '*';
   resolveRedirect?: boolean;
@@ -100,6 +105,7 @@ export async function getPerson(
   options?: ApiOptions
 ): Promise<Person> {
   const request: GetPersonRequest = {
+    appId: args?.appId,
     action: 'getPerson',
     key,
     bioFormat: args?.bioFormat,
@@ -113,6 +119,7 @@ export async function getPerson(
 
 /** Optional arguments for the GetAncestors API call. */
 interface GetAncestorsArgs {
+  appId?: string;
   depth?: number;
   bioFormat?: BioFormat;
   fields?: Array<PersonField> | '*';
@@ -130,6 +137,7 @@ export async function getAncestors(
   options?: ApiOptions
 ): Promise<Person[]> {
   const request: GetAncestorsRequest = {
+    appId: args?.appId,
     action: 'getAncestors',
     key,
     depth: args?.depth,
@@ -144,6 +152,7 @@ export async function getAncestors(
 
 /** Optional arguments for the GetRelatives API call. */
 export interface GetRelativesArgs {
+  appId?: string;
   getParents?: boolean;
   getChildren?: boolean;
   getSpouses?: boolean;
@@ -154,6 +163,7 @@ export interface GetRelativesArgs {
 
 /** Optional arguments for the GetDescendants API call. */
 interface GetDescendantsArgs {
+  appId?: string;
   depth?: number;
   bioFormat?: BioFormat;
   fields?: Array<PersonField> | '*';
@@ -171,6 +181,7 @@ export async function getDescendants(
   options?: ApiOptions
 ): Promise<Person[]> {
   const request: GetDescendantsRequest = {
+    appId: args?.appId,
     action: 'getDescendants',
     key,
     depth: args?.depth,
@@ -201,6 +212,7 @@ export async function getRelatives(
     );
   }
   const request: GetRelativesRequest = {
+    appId: args?.appId,
     action: 'getRelatives',
     keys: keys.join(','),
     getParents: args?.getParents ? 'true' : undefined,
@@ -282,9 +294,11 @@ export function navigateToLoginPage(returnUrl: string) {
 }
 
 export async function clientLogin(
-  authcode: string
+  authcode: string,
+  appId?: string
 ): Promise<ClientLoginResponse> {
   const response = await wikiTreeGet({
+    appId: appId,
     action: 'clientLogin',
     authcode,
   });
@@ -310,8 +324,13 @@ export async function login(
   return { cookies: await getAuthCookies(authcode) };
 }
 
-async function getAuthcode(email: string, password: string): Promise<string> {
+async function getAuthcode(
+  email: string,
+  password: string,
+  appId?: string
+): Promise<string> {
   const response = await fetchWikiTree({
+    appId: appId,
     action: 'clientLogin',
     doLogin: 1,
     returnURL: 'https://x/',
@@ -324,8 +343,12 @@ async function getAuthcode(email: string, password: string): Promise<string> {
   return response.headers.get('location')!.replace('https://x/?authcode=', '');
 }
 
-async function getAuthCookies(authcode: string): Promise<string> {
+async function getAuthCookies(
+  authcode: string,
+  appId?: string
+): Promise<string> {
   const response = await fetchWikiTree({
+    appId: appId,
     action: 'clientLogin',
     authcode,
   });

--- a/src/wikitree_types.ts
+++ b/src/wikitree_types.ts
@@ -149,6 +149,7 @@ export type BioFormat = 'wiki' | 'html' | 'both';
  * See also: https://github.com/wikitree/wikitree-api/blob/main/getPerson.md
  */
 export interface GetPersonRequest {
+  appId?: string;
   action: 'getPerson';
   key: string;
   bioFormat?: BioFormat;
@@ -162,6 +163,7 @@ export interface GetPersonRequest {
  * See also: https://github.com/wikitree/wikitree-api/blob/main/getAncestors.md
  */
 export interface GetAncestorsRequest {
+  appId?: string;
   action: 'getAncestors';
   key: string;
   depth?: number;
@@ -176,6 +178,7 @@ export interface GetAncestorsRequest {
  * See also: https://github.com/wikitree/wikitree-api/blob/main/getDescendants.md
  */
 export interface GetDescendantsRequest {
+  appId?: string;
   action: 'getDescendants';
   key: string;
   depth?: number;
@@ -190,6 +193,7 @@ export interface GetDescendantsRequest {
  * See also: https://github.com/wikitree/wikitree-api/blob/main/getRelatives.md
  */
 export interface GetRelativesRequest {
+  appId?: string;
   action: 'getRelatives';
   keys: string;
   getParents?: 'true';
@@ -202,6 +206,7 @@ export interface GetRelativesRequest {
 
 /** WikiTree API clientLogin request. */
 export interface ClientLoginRequest {
+  appId?: string;
   action: 'clientLogin';
   authcode: string;
 }

--- a/tests/wikitree_api.test.ts
+++ b/tests/wikitree_api.test.ts
@@ -61,6 +61,7 @@ describe('fetchWikiTree', () => {
     const requestedData = mockedFetch.mock.calls[0][1].body as any as FormData;
     expectFormDataToContainData(requestedData, {
       format: 'json',
+      appId: 'wikitree-js',
       action: 'getPerson',
       key: 'Test-1',
       fields: 'Name,Id',
@@ -111,6 +112,27 @@ describe('fetchWikiTree', () => {
       })
     );
   });
+
+  test('send custom appId', async () => {
+    mockFetch({});
+
+    await wikiTreeGet(
+      {
+        action: 'getPerson',
+        key: 'Test-1',
+      },
+      { appId: 'custom-id' }
+    );
+
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    const requestedData = mockedFetch.mock.calls[0][1].body as any as FormData;
+    expectFormDataToContainData(requestedData, {
+      format: 'json',
+      appId: 'custom-id',
+      action: 'getPerson',
+      key: 'Test-1',
+    });
+  });
 });
 
 describe('getPerson', () => {
@@ -124,6 +146,7 @@ describe('getPerson', () => {
     const requestedData = mockedFetch.mock.calls[0][1].body as any as FormData;
     expectFormDataToContainData(requestedData, {
       format: 'json',
+      appId: 'wikitree-js',
       action: 'getPerson',
       key: 'Test-1',
     });
@@ -143,6 +166,7 @@ describe('getPerson', () => {
     const requestedData = mockedFetch.mock.calls[0][1].body as any as FormData;
     expectFormDataToContainData(requestedData, {
       format: 'json',
+      appId: 'wikitree-js',
       action: 'getPerson',
       key: 'Test-1',
       bioFormat: 'html',
@@ -164,6 +188,7 @@ describe('getAncestors', () => {
     const requestedData = mockedFetch.mock.calls[0][1].body as any as FormData;
     expectFormDataToContainData(requestedData, {
       format: 'json',
+      appId: 'wikitree-js',
       action: 'getAncestors',
       key: 'Test-1',
     });
@@ -185,6 +210,7 @@ describe('getAncestors', () => {
     const requestedData = mockedFetch.mock.calls[0][1].body as any as FormData;
     expectFormDataToContainData(requestedData, {
       format: 'json',
+      appId: 'wikitree-js',
       action: 'getAncestors',
       key: 'Test-1',
       depth: '2',
@@ -207,6 +233,7 @@ describe('getDescendants', () => {
     const requestedData = mockedFetch.mock.calls[0][1].body as any as FormData;
     expectFormDataToContainData(requestedData, {
       format: 'json',
+      appId: 'wikitree-js',
       action: 'getDescendants',
       key: 'Test-1',
     });
@@ -228,6 +255,7 @@ describe('getDescendants', () => {
     const requestedData = mockedFetch.mock.calls[0][1].body as any as FormData;
     expectFormDataToContainData(requestedData, {
       format: 'json',
+      appId: 'wikitree-js',
       action: 'getDescendants',
       key: 'Test-1',
       depth: '2',
@@ -250,6 +278,7 @@ describe('getRelatives', () => {
     const requestedData = mockedFetch.mock.calls[0][1].body as any as FormData;
     expectFormDataToContainData(requestedData, {
       format: 'json',
+      appId: 'wikitree-js',
       action: 'getRelatives',
       keys: 'Test-1',
     });
@@ -273,6 +302,7 @@ describe('getRelatives', () => {
     const requestedData = mockedFetch.mock.calls[0][1].body as any as FormData;
     expectFormDataToContainData(requestedData, {
       format: 'json',
+      appId: 'wikitree-js',
       action: 'getRelatives',
       keys: 'Test-1',
       getParents: 'true',


### PR DESCRIPTION
Allow the [optional] new [appId parameter](https://github.com/wikitree/wikitree-api/blob/main/README.md#application-id) to be set via either the request arguments or ApiOptions. Needed for a [recent update](https://github.com/wikitree/wikitree-browser-extension/pull/304) to WBE to track usage by feature.